### PR TITLE
fix: documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It's an official version for JavaScript, available for Node.js backends, Serverl
 
 ###### With yarn
 ```
-yarn install @youngapp/yap
+yarn add @youngapp/yap
 ```
 
 ###### With npm


### PR DESCRIPTION
Updating the command for installing yap package through `yarn`. 
I btw was just trying the package out and I found out of this issue. I see project is not maintained actively as I recall the main project is not open source anymore ( I used to be in the slack group btw ).